### PR TITLE
Use internal iiif api in viewer

### DIFF
--- a/app/Resources/SubugoeFindBundle/views/Default/detail.html.twig
+++ b/app/Resources/SubugoeFindBundle/views/Default/detail.html.twig
@@ -6,10 +6,8 @@
 
 {% block content %}
 
-    {% set images = [document.thumbs_url] | merge([document.min_url])  %}
-
     {# Viewer settings #}
-    {% set pageCount = images.0|length %}
+    {% set pageCount = document.presentation_url.0|length %}
 
     {% set showDoublePage = app.request.get('showDoublePage') == 'true' %}
     {% set page = app.request.get('page')|number_format %}

--- a/app/Resources/SubugoeFindBundle/views/Default/partials/footer.html.twig
+++ b/app/Resources/SubugoeFindBundle/views/Default/partials/footer.html.twig
@@ -1,11 +1,11 @@
 <footer class="viewer_footer">
     {% if document.thumbs_url is defined %}
         <div id="coverflow" class="coverflow">
-            {% for image in images.0 %}
+            {% for image in document.presentation_url %}
                 {% set link = document.id ~ '?page=' ~ loop.index ~ (showDoublePage ? '&showDoublePage=true') %}
                 {% set isCurrent = page == loop.index or secondPage == loop.index %}
                 <a class="coverflow_link {{ isCurrent ? '-current' }}" {{ not isCurrent ? 'href=' ~ link }}>
-                    <img data-original="{{ image }}" alt="">
+                    <img data-original="{{ path('_image', {'format': 'jpg', 'identifier': (image | replace({'http://gdz.sub.uni-goettingen.de/tiff/': '','.tif': '', '/': ':'})), 'region': 'full', 'size': '59,78', 'rotation': 0, 'quality': 'default'})  }}" alt="">
                     <span class="coverflow_page-number">
                         <span class="sr-only">{% trans %}Go to page{% endtrans %}</span>
                         {{ loop.index }}

--- a/app/Resources/SubugoeFindBundle/views/Default/partials/scan.html.twig
+++ b/app/Resources/SubugoeFindBundle/views/Default/partials/scan.html.twig
@@ -30,7 +30,7 @@
                 <label class="sr-only double-page" for="viewer-page-select-2">{% trans %}Current pages{% endtrans %}</label>
                 <select class="viewer_control double-page js-select-page" name="page" id="viewer-page-select-2">
                     <option {{ page == 1 ? 'selected' }}>1</option>
-                    {% for image in images.0 %}
+                    {% for image in document.presentation_url %}
                         {% if loop.index > 1 and loop.index % 2 == 1 %}
                             <option {{ page == loop.index - 1 or page == loop.index ? 'selected' }} value="{{ loop.index }}">{{ loop.index - 1 }} | {{ loop.index }}</option>
                         {% endif %}
@@ -42,7 +42,7 @@
             {% else %}
                 <label class="sr-only single-page" for="viewer-page-select">{% trans %}Current page{% endtrans %}</label>
                 <select class="viewer_control single-page js-select-page" name="page" id="viewer-page-select">
-                    {% for image in images.0 %}
+                    {% for image in document.presentation_url %}
                         <option {{ loop.index == page ? 'selected' }}>{{ loop.index }}</option>
                     {% endfor %}
                 </select>
@@ -85,8 +85,8 @@
     </div>
     <div class="viewer_image {{ showDoublePage ? '-double' }}" id="viewer_scan">
         {% if secondPage %}
-            <img src="{{ images.1[page - 2] }}" alt="">
+            <img src="{{ path('_image', {'format': 'jpg', 'identifier': (document.presentation_url[page - 2] | replace({'http://gdz.sub.uni-goettingen.de/tiff/': '','.tif': '', '/': ':'})), 'region': 'full', 'size': '1024,', 'rotation': 0, 'quality': 'default'}) }}" alt="">
         {% endif %}
-        <img src="{{ images.1[page - 1] }}" alt="">
+        <img src="{{ path('_image', {'format': 'jpg', 'identifier': (document.presentation_url[page - 1] | replace({'http://gdz.sub.uni-goettingen.de/tiff/': '','.tif': '', '/': ':'})), 'region': 'full', 'size': '1024,', 'rotation': 0, 'quality': 'default'}) }}" alt="">
     </div>
 </section>

--- a/tests/config.js
+++ b/tests/config.js
@@ -1,6 +1,5 @@
 var config = {
     base: 'http://localhost:8000',
-    imageBase:  'http://gdz.sub.uni-goettingen.de/content',
     docId: 'PPN530582384',
     docTitle: 'Michael',
 };

--- a/tests/end2end/viewer-double-page.js
+++ b/tests/end2end/viewer-double-page.js
@@ -27,8 +27,8 @@ casper.test.begin('Viewer: Double page', function suite(test) {
             casper.getElementAttribute('.viewer_image > img:nth-child(2)', 'src'),
         ];
         var expectedImageSrcs = [
-            config.imageBase + '/' + config.docId + '/500/0/00000002.jpg',
-            config.imageBase + '/' + config.docId + '/500/0/00000003.jpg',
+            '/image/' + config.docId + ':00000002/full/1024,',
+            '/image/' + config.docId + ':00000003/full/1024,',
         ];
         test.assertEquals(actualImageSrcs, expectedImageSrcs, 'The scans of pages 2 and 3 are being displayed');
     });

--- a/tests/end2end/viewer-startup.js
+++ b/tests/end2end/viewer-startup.js
@@ -3,7 +3,7 @@ casper.test.begin('Viewer: Startup', function suite(test) {
         var title = casper.fetchText('h1');
         test.assertEquals(title, config.docTitle, 'The correct document title is shown');
         var imageSrc = casper.getElementAttribute('.viewer_image > img', 'src');
-        test.assertEquals(imageSrc, config.imageBase + '/' +  config.docId + '/500/0/00000001.jpg', 'The first page\'s scan is displayed');
+        test.assertEquals(imageSrc, '/image/' + config.docId + ':00000001/full/1024,', 'The first page\'s scan is displayed');
     });
 
     casper.run(function () {


### PR DESCRIPTION
This uses the internal iiif api for all image calls in the viewer
instead of using predefined and pre-rendered images.